### PR TITLE
Ignore Cocoapods autogenerated project

### DIFF
--- a/src/config/ios/findProject.js
+++ b/src/config/ios/findProject.js
@@ -8,7 +8,7 @@ const GLOB_PATTERN = '**/*.xcodeproj';
 /**
  * These folders will be excluded from search to speed it up
  */
-const GLOB_EXCLUDE_PATTERN = ['node_modules/**', 'Examples/**', 'examples/**'];
+const GLOB_EXCLUDE_PATTERN = ['node_modules/**', 'Examples/**', 'examples/**', 'Pods/**'];
 
 /**
  * Finds iOS project by looking for all .xcodeproj files


### PR DESCRIPTION
We are migrating to `rnpm`, and some of our projects use Cocoapods for most popular non-RN third-party libs such as Segment, AppFlyer, etc. Cocoapods creates an additional XCode project to keep all frameworks there. So `rnpm` finds two projects `[ 'Pods/Pods.xcodeproj', 'MyProject.xcodeproj' ]` and returns only the first one.

This fixes `rnpm` `findProject` by simply ignoring that autogenerated project. 