### PR TITLE
Better CI integration with deployment section

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -3,9 +3,11 @@ engines:
     enabled: true
   fixme:
     enabled: false
+
 ratings:
   paths:
   - "**.js"
   - "**.jsx"
+
 exclude_paths:
   - test/*

--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,14 @@
 machine:
   node:
     version: 4.2.1
-test:
-  post:
-    - npm run coverage
-    - ./coverage.sh
+
+deployment:
+  coverage:
+    branch: master
+    commands:
+      - npm run coverage
+      - codeclimate-test-reporter < coverage/lcov.info
+
 notify:
   webhooks:
     - url: https://webhooks.gitter.im/e/bf9cb7240681c7263e6b

--- a/circle.yml
+++ b/circle.yml
@@ -5,6 +5,7 @@ machine:
 deployment:
   coverage:
     branch: master
+    owner: rnpm
     commands:
       - npm run coverage
       - codeclimate-test-reporter < coverage/lcov.info

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-BRANCH=$(git symbolic-ref --short HEAD)
-MAIN_BRANCH="master"
-
-if [ $BRANCH == $MAIN_BRANCH ]; then
-  codeclimate-test-reporter < coverage/lcov.info
-fi


### PR DESCRIPTION
This pull request removes custom bash script (well, actually it copies its main method back into circle.yml) and uses deployment section that can be run only on given branches (in our case - it's coverage).