### PR TITLE
Allow users to define project assets

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -18,6 +18,7 @@ exports.getProjectConfig = function getProjectConfig() {
   return Object.assign({}, rnpm, {
     ios: ios.projectConfig(folder, rnpm.ios || {}),
     android: android.projectConfig(folder, rnpm.android || {}),
+    assets: findAssets(folder, rnpm.assets),
   });
 };
 


### PR DESCRIPTION
Fixes #19 

Thanks to the array of project assets (defined in exactly same way as dependency assets), we can now support that use-case in `rnpm-link` quite easily. Now one can just define `rnpm.assets` in project package.json to not only have custom fonts linked automatically but also to e.g. link automatically fonts from `node_modules/project` that does not support that.

Example:
```json
{
  "rnpm": {"assets": ["node_modules/react-native-vector-icons/Fonts", "assets/fonts"]}
}
```

Similar PR in rnpm-plugin-link exists --> https://github.com/rnpm/rnpm-plugin-link/pull/10 that implements that functionality.

Note this is not even changing anything, so can be safely merged w/o affecting the ecosystem.