### PR TITLE
More robust globbing

### DIFF
--- a/src/config/ios/findProject.js
+++ b/src/config/ios/findProject.js
@@ -8,7 +8,7 @@ const GLOB_PATTERN = '**/*.xcodeproj';
 /**
  * These folders will be excluded from search to speed it up
  */
-const GLOB_EXCLUDE_PATTERN = ['node_modules/**', 'Examples/**', 'examples/**', 'Pods/**'];
+const GLOB_EXCLUDE_PATTERN = ['node_modules/**', '**/@(E|e)xamples/**', '**/*@(T|t)est*/**', 'Pods/**'];
 
 /**
  * Finds iOS project by looking for all .xcodeproj files

--- a/test/fixtures/ios.js
+++ b/test/fixtures/ios.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 exports.valid = {
-  'testProject.xcodeproj': {
+  'sampleProject.xcodeproj': {
     'project.pbxproj': fs.readFileSync(path.join(__dirname, './files/project.pbxproj')),
   },
 };

--- a/test/fixtures/projects.js
+++ b/test/fixtures/projects.js
@@ -15,10 +15,4 @@ const nested = {
   ios: ios.valid,
 };
 
-const withExamples = {
-  Examples: flat,
-  ios: ios.valid,
-  android: android.valid,
-};
-
-module.exports = { flat, nested, withExamples, };
+module.exports = { flat, nested };

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -12,20 +12,41 @@ describe('ios::findProject', () => {
 
   it('should return path to xcodeproj if found', () => {
     const userConfig = {};
-    const folder = path.join('testDir', 'flat');
 
-    expect(findProject(folder)).to.contain('.xcodeproj');
+    mockFs(projects.flat);
+
+    expect(findProject('')).to.contain('.xcodeproj');
   });
 
-  it('should ignore xcodeproj from examples', () => {
+  it('should ignore xcodeproj from example folders', () => {
     const userConfig = {};
-    const folder = path.join('testDir', 'withExamples');
 
-    expect(findProject(folder)).to.not.contain('Examples');
+    mockFs({
+      examples: projects.flat,
+      Examples: projects.flat,
+      App: projects.flat,
+    });
+
+    expect(findProject('').toLowerCase()).to.not.contain('examples');
   });
 
+  it('should ignore xcodeproj from test folders at any level', () => {
+    const userConfig = {};
 
-  after(() => {
+    mockFs({
+      test: projects.flat,
+      IntegrationTests: projects.flat,
+      tests: projects.flat,
+      app: {
+        tests: projects.flat,
+        src: projects.flat,
+      },
+    });
+
+    expect(findProject('').toLowerCase()).to.not.contain('tests');
+  });
+
+  afterEach(() => {
     mockFs.restore();
   });
 

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -43,7 +43,7 @@ describe('ios::findProject', () => {
       },
     });
 
-    expect(findProject('').toLowerCase()).to.not.contain('tests');
+    expect(findProject('').toLowerCase()).to.not.contain('test');
   });
 
   afterEach(() => {


### PR DESCRIPTION
Solves issues with test folders and removes two patterns for `examples`. Also, adds more tests to that (follows rnpm-plugin-link pattern and declares mocked filesystem inline with test suite) 