### PR TITLE
Getting rid of using projects.js for android tests

### DIFF
--- a/src/config/android/findAndroidAppFolder.js
+++ b/src/config/android/findAndroidAppFolder.js
@@ -6,13 +6,16 @@ const path = require('path');
  * @return {String}
  */
 module.exports = function findAndroidAppFolder(folder) {
-  if (!fs.existsSync(path.join(folder, 'android'))) {
-    return null;
+  const flat = 'android';
+  const nested = path.join('android', 'app');
+
+  if (fs.existsSync(path.join(folder, nested))) {
+    return nested;
   }
 
-  if (fs.existsSync(path.join(folder, 'android', 'app'))) {
-    return path.join('android', 'app');
+  if (fs.existsSync(path.join(folder, flat))) {
+    return flat;
   }
 
-  return 'android';
+  return null;
 };

--- a/test/android/findAndroidAppFolder.spec.js
+++ b/test/android/findAndroidAppFolder.spec.js
@@ -2,28 +2,30 @@ const path = require('path');
 const expect = require('chai').expect;
 const findAndroidAppFolder = require('../../src/config/android/findAndroidAppFolder');
 const mockFs = require('mock-fs');
-const projects = require('../fixtures/projects');
+const mocks = require('../fixtures/android');
 
 describe('android::findAndroidAppFolder', () => {
 
-  before(() => {
-    mockFs({ testDir: projects });
-  });
+  before(() => mockFs({
+    empty: {},
+    nested: {
+      android: {
+        app: mocks.valid,
+      },
+    },
+    flat: {
+      android: mocks.valid,
+    },
+  }));
 
   it('should return an android app folder if it exists in the given folder', () => {
-    const flat = path.join('testDir', 'flat');
-    const nested = path.join('testDir', 'nested');
-
-    expect(findAndroidAppFolder(flat)).to.be.equal('android');
-    expect(findAndroidAppFolder(nested)).to.be.equal(path.join('android', 'app'));
+    expect(findAndroidAppFolder('flat')).to.be.equal('android');
+    expect(findAndroidAppFolder('nested')).to.be.equal(path.join('android', 'app'));
   });
 
   it('should return `null` if there\'s no android app folder', () => {
-    const emptyFolder = path.join('testDir', 'empty');
-    expect(findAndroidAppFolder(emptyFolder)).to.be.null;
+    expect(findAndroidAppFolder('empty')).to.be.null;
   });
 
-  after(() => {
-    mockFs.restore();
-  });
+  after(mockFs.restore);
 });

--- a/test/android/findManifest.spec.js
+++ b/test/android/findManifest.spec.js
@@ -2,26 +2,24 @@ const path = require('path');
 const expect = require('chai').expect;
 const findManifest = require('../../src/config/android/findManifest');
 const mockFs = require('mock-fs');
-const projects = require('../fixtures/projects');
+const mocks = require('../fixtures/android');
 
 describe('android::findManifest', () => {
 
-  before(() => {
-    mockFs({ testDir: projects });
-  });
+  before(() => mockFs({
+    empty: {},
+    flat: {
+      android: mocks.valid,
+    },
+  }));
 
   it('should return a manifest path if file exists in the folder', () => {
-    const fixturesPath = path.join('testDir', 'flat');
-    expect(findManifest(fixturesPath)).to.be.a('string');
+    expect(findManifest('flat')).to.be.a('string');
   });
 
   it('should return `null` if there is no manifest in the folder', () => {
-    const emptyFolder = path.join('testDir', 'empty');
-    expect(findManifest(emptyFolder)).to.be.null;
+    expect(findManifest('empty')).to.be.null;
   });
 
-  after(() => {
-    mockFs.restore();
-  });
-
+  after(mockFs.restore);
 });

--- a/test/android/findPackageClassName.spec.js
+++ b/test/android/findPackageClassName.spec.js
@@ -2,26 +2,24 @@ const path = require('path');
 const expect = require('chai').expect;
 const findPackageClassName = require('../../src/config/android/findPackageClassName');
 const mockFs = require('mock-fs');
-const projects = require('../fixtures/projects');
+const mocks = require('../fixtures/android');
 
 describe('android::findPackageClassName', () => {
 
-  before(() => {
-    mockFs({ testDir: projects });
-  });
+  before(() => mockFs({
+    empty: {},
+    flat: {
+      android: mocks.valid,
+    },
+  }));
 
   it('should return manifest content if file exists in the folder', () => {
-    const fixturesFolder = path.join('testDir', 'flat');
-    expect(findPackageClassName(fixturesFolder)).to.be.a('string');
+    expect(findPackageClassName('flat')).to.be.a('string');
   });
 
   it('should return `null` if there\'s no matches', () => {
-    const emptyFolder = path.join('testDir', 'empty');
-    expect(findPackageClassName(emptyFolder)).to.be.null;
+    expect(findPackageClassName('empty')).to.be.null;
   });
 
-  after(() => {
-    mockFs.restore();
-  });
-
+  after(mockFs.restore);
 });

--- a/test/android/getDependencyConfig.spec.js
+++ b/test/android/getDependencyConfig.spec.js
@@ -2,43 +2,49 @@ const path = require('path');
 const expect = require('chai').expect;
 const getDependencyConfig = require('../../src/config/android').dependencyConfig;
 const mockFs = require('mock-fs');
-const dependencies = require('../fixtures/dependencies');
+const mocks = require('../fixtures/android');
 
 describe('android::getDependencyConfig', () => {
 
-  before(() => {
-    mockFs({ testDir: dependencies });
-  });
+  before(() => mockFs({
+    empty: {},
+    nested: {
+      android: {
+        app: mocks.valid,
+      },
+    },
+    noPackage: {
+      android: {},
+    },
+  }));
 
   it('should return an object with android project configuration', () => {
     const userConfig = {};
-    const folder = path.join('testDir', 'valid');
+    const folder = 'nested';
 
     expect(getDependencyConfig(folder, userConfig)).to.be.an('object');
   });
 
   it('should return `null` if manifest file hasn\'t been found', () => {
     const userConfig = {};
-    const folder = path.join('testDir', 'empty');
+    const folder = 'empty';
 
     expect(getDependencyConfig(folder, userConfig)).to.be.null;
   });
 
   it('should return `null` if android project was not found', () => {
     const userConfig = {};
-    const folder = path.join('testDir', 'empty');
+    const folder = 'empty';
 
     expect(getDependencyConfig(folder, userConfig)).to.be.null;
   });
 
   it('should return `null` if android project does not contain ReactPackage', () => {
     const userConfig = {};
-    const folder = path.join('testDir', 'noPackage');
+    const folder = 'noPackage';
 
     expect(getDependencyConfig(folder, userConfig)).to.be.null;
   });
 
-  after(() => {
-    mockFs.restore();
-  });
+  after(mockFs.restore);
 });

--- a/test/android/getProjectConfig.spec.js
+++ b/test/android/getProjectConfig.spec.js
@@ -2,37 +2,53 @@ const path = require('path');
 const expect = require('chai').expect;
 const getProjectConfig = require('../../src/config/android').projectConfig;
 const mockFs = require('mock-fs');
-const projects = require('../fixtures/projects');
+const mocks = require('../fixtures/android');
 
 describe('android::getProjectConfig', () => {
-
-  before(() => {
-    mockFs({ testDir: projects });
-  });
+  before(() => mockFs({
+    empty: {},
+    nested: {
+      android: {
+        app: mocks.valid,
+      },
+    },
+    flat: {
+      android: mocks.valid,
+    },
+    noManifest: {
+      android: {},
+    },
+  }));
 
   it('should return `null` if manifest file hasn\'t been found', () => {
     const userConfig = {};
-    const folder = path.join('testDir', 'empty');
+    const folder = 'noManifest';
 
     expect(getProjectConfig(folder, userConfig)).to.be.null;
   });
 
-  it('should return an object with android project configuration', () => {
-    const userConfig = {};
-    const folder = path.join('testDir', 'nested');
+  describe('return an object with android project configuration for', () => {
+    it('nested structure', () => {
+      const userConfig = {};
+      const folder = 'nested';
 
-    expect(getProjectConfig(folder, userConfig)).to.be.an('object');
+      expect(getProjectConfig(folder, userConfig)).to.be.an('object');
+    });
+
+    it('flat structure', () => {
+      const userConfig = {};
+      const folder = 'flat';
+
+      expect(getProjectConfig(folder, userConfig)).to.be.an('object');
+    });
   });
 
   it('should return `null` if android project was not found', () => {
     const userConfig = {};
-    const folder = path.join('testDir', 'empty');
+    const folder = 'empty';
 
     expect(getProjectConfig(folder, userConfig)).to.be.null;
   });
 
-  after(() => {
-    mockFs.restore();
-  });
-
+  after(mockFs.restore);
 });

--- a/test/android/readManifest.spec.js
+++ b/test/android/readManifest.spec.js
@@ -1,28 +1,30 @@
 const path = require('path');
 const expect = require('chai').expect;
+const findManifest = require('../../src/config/android/findManifest');
 const readManifest = require('../../src/config/android/readManifest');
 const mockFs = require('mock-fs');
-const projects = require('../fixtures/projects');
+const mocks = require('../fixtures/android');
 
 describe('android::readManifest', () => {
 
-  before(() => {
-    mockFs({ testDir: projects });
-  });
+  before(() => mockFs({
+    empty: {},
+    nested: {
+      android: {
+        app: mocks.valid,
+      },
+    },
+  }));
 
   it('should return manifest content if file exists in the folder', () => {
-    const manifestPath = path.join(
-      'testDir', 'flat', 'android', 'src', 'AndroidManifest.xml'
-    );
-
+    const manifestPath = findManifest('nested');
     expect(readManifest(manifestPath)).to.be.an('object');
   });
 
   it('should throw an error if there is no manifest in the folder', () => {
-    const fakeManifestPath = path.join('testDir', 'empty', 'AndroidManifest.xml');
+    const fakeManifestPath = findManifest('empty');
     expect(() => readManifest(fakeManifestPath)).to.throw(Error);
   });
 
   after(mockFs.restore);
-
 });

--- a/test/fixtures/projects.js
+++ b/test/fixtures/projects.js
@@ -15,4 +15,10 @@ const nested = {
   ios: ios.valid,
 };
 
-module.exports = { flat, nested };
+const withExamples = {
+  Examples: flat,
+  ios: ios.valid,
+  android: android.valid,
+};
+
+module.exports = { flat, nested, withExamples };


### PR DESCRIPTION
Some clean-ups in android tests. I think we no need `projects.js`: use case is really small for the overhead it introduce (imo). So I require android mocks directly from the tests and wrap them up if it's needed. 