### PR TITLE
Ignore if contains, not starts/ends with

### DIFF
--- a/src/config/ios/findProject.js
+++ b/src/config/ios/findProject.js
@@ -8,7 +8,7 @@ const GLOB_PATTERN = '**/*.xcodeproj';
 /**
  * These folders will be excluded from search to speed it up
  */
-const GLOB_EXCLUDE_PATTERN = ['node_modules/**', '**/@(E|e)xamples/**', '**/*@(T|t)est*/**', 'Pods/**'];
+const GLOB_EXCLUDE_PATTERN = ['node_modules/**', '**/*@(E|e)xample*/**', '**/*@(T|t)est*/**', 'Pods/**'];
 
 /**
  * Finds iOS project by looking for all .xcodeproj files

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -24,10 +24,12 @@ describe('ios::findProject', () => {
     mockFs({
       examples: projects.flat,
       Examples: projects.flat,
-      App: projects.flat,
+      example: projects.flat,
+      KeychainExample: projects.flat,
+      Zpp: projects.flat,
     });
 
-    expect(findProject('').toLowerCase()).to.not.contain('examples');
+    expect(findProject('').toLowerCase()).to.not.contain('example');
   });
 
   it('should ignore xcodeproj from test folders at any level', () => {
@@ -37,7 +39,7 @@ describe('ios::findProject', () => {
       test: projects.flat,
       IntegrationTests: projects.flat,
       tests: projects.flat,
-      app: {
+      Zpp: {
         tests: projects.flat,
         src: projects.flat,
       },


### PR DESCRIPTION
This is similar to what we have been doing with tests. Since glob goes alphabetically through folders, I've renamed `app` to `zpp` just to make sure it first checks `examples` and `tests`