### PR TITLE
Export isFlat flag for the projectConfig

### DIFF
--- a/src/config/android/index.js
+++ b/src/config/android/index.js
@@ -21,6 +21,7 @@ exports.projectConfig = function projectConfigAndroid(folder, userConfig) {
   }
 
   const sourceDir = path.join(folder, src);
+  const isFlat = sourceDir.indexOf('app') === -1;
   const manifestPath = findManifest(sourceDir);
 
   if (!manifestPath) {
@@ -56,6 +57,7 @@ exports.projectConfig = function projectConfigAndroid(folder, userConfig) {
 
   return {
     sourceDir,
+    isFlat,
     folder,
     manifestPath,
     buildGradlePath,


### PR DESCRIPTION
Expose `isFlat` flag in projectConfig. It's required because of https://github.com/rnpm/rnpm-plugin-link/pull/28