### PR TITLE
Use .bin env for script shortcuts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "React Native Package Manager",
   "main": "./src/getActions.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha --recursive",
-    "coverage": "node_modules/istanbul/lib/cli.js cover node_modules/.bin/_mocha -- --recursive"
+    "test": "mocha --recursive",
+    "coverage": "istanbul cover _mocha -- --recursive"
   },
   "bin": {
     "rnpm": "bin/cli"


### PR DESCRIPTION
Use a shortcut version for the npm scripts using local modules (see https://docs.npmjs.com/files/folders#executables)