### PR TITLE
Make cc test reporter a very specific CI dependency

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,10 +1,12 @@
 machine:
+  pre:
+    - npm install codeclimate-test-reporter
   node:
     version: 4.2.1
 
 deployment:
   coverage:
-    branch: master
+    branch: /*/
     owner: rnpm
     commands:
       - npm run coverage

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
   "devDependencies": {
     "babel-eslint": "^4.1.5",
     "chai": "^3.4.1",
-    "codeclimate-test-reporter": "^0.1.1",
     "eslint": "^1.9.0",
     "istanbul": "^0.4.1",
     "mocha": "^2.3.4",


### PR DESCRIPTION
Moved `codeclimate-test-reporter` to the `pre` machine hook.