### PR TITLE
Replace mocha+chai+sinon by Jest

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,9 +4,8 @@ machine:
 
 test:
   pre:
-    - npm install codeclimate-test-reporter@0.1 istanbul@0.4
+    - npm install codeclimate-test-reporter@0.1
   post:
-    - npm run coverage
     - codeclimate-test-reporter < coverage/lcov.info
 
 notify:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "jest": {
     "testDirectoryName": "test",
-    "testPathIgnorePatterns": ["/node_modules/", "/test/fixtures/"],
     "collectCoverage": true
   },
   "bin": {
@@ -52,6 +51,6 @@
     "mock-fs": "^3.5.0",
     "mock-require": "^1.2.1",
     "rewire": "^2.5.1",
-    "jest-cli": "^0.8.2"
+    "jest-cli": "^0.9.0-fb2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "React Native Package Manager",
   "main": "./src/getActions.js",
   "scripts": {
-    "test": "jest",
-    "coverage": "istanbul cover _mocha -- --recursive"
+    "test": "jest"
   },
   "jest": {
     "testDirectoryName": "test",

--- a/package.json
+++ b/package.json
@@ -4,8 +4,12 @@
   "description": "React Native Package Manager",
   "main": "./src/getActions.js",
   "scripts": {
-    "test": "mocha --recursive",
+    "test": "jest",
     "coverage": "istanbul cover _mocha -- --recursive"
+  },
+  "jest": {
+    "testDirectoryName": "test",
+    "testPathIgnorePatterns": ["/node_modules/", "/test/fixtures/"]
   },
   "bin": {
     "rnpm": "bin/cli"
@@ -44,12 +48,10 @@
   },
   "devDependencies": {
     "babel-eslint": "^4.1.5",
-    "chai": "^3.4.1",
     "eslint": "^1.9.0",
-    "mocha": "^2.3.4",
     "mock-fs": "^3.5.0",
     "mock-require": "^1.2.1",
     "rewire": "^2.5.1",
-    "sinon": "^1.17.2"
+    "jest-cli": "^0.8.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "jest": {
     "testDirectoryName": "test",
-    "testPathIgnorePatterns": ["/node_modules/", "/test/fixtures/"]
+    "testPathIgnorePatterns": ["/node_modules/", "/test/fixtures/"],
+    "collectCoverage": true
   },
   "bin": {
     "rnpm": "bin/cli"

--- a/src/makeCommand.js
+++ b/src/makeCommand.js
@@ -16,7 +16,7 @@ module.exports = function makeCommand(command) {
 
     commandProcess.on('close', function prelink(code) {
       if (code) {
-        cb(new Error(`Error occured during executing "${command}" command`));
+        throw new Error(`Error occured during executing "${command}" command`);
       }
 
       cb();

--- a/test/android/findAndroidAppFolder.spec.js
+++ b/test/android/findAndroidAppFolder.spec.js
@@ -1,12 +1,11 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const findAndroidAppFolder = require('../../src/config/android/findAndroidAppFolder');
 const mockFs = require('mock-fs');
 const mocks = require('../fixtures/android');
 
 describe('android::findAndroidAppFolder', () => {
-
-  before(() => mockFs({
+  beforeEach(() => mockFs({
     empty: {},
     nested: {
       android: {
@@ -19,13 +18,13 @@ describe('android::findAndroidAppFolder', () => {
   }));
 
   it('should return an android app folder if it exists in the given folder', () => {
-    expect(findAndroidAppFolder('flat')).to.be.equal('android');
-    expect(findAndroidAppFolder('nested')).to.be.equal(path.join('android', 'app'));
+    expect(findAndroidAppFolder('flat')).toBe('android');
+    expect(findAndroidAppFolder('nested')).toBe('android/app');
   });
 
   it('should return `null` if there\'s no android app folder', () => {
-    expect(findAndroidAppFolder('empty')).to.be.null;
+    expect(findAndroidAppFolder('empty')).toBe(null);
   });
 
-  after(mockFs.restore);
+  afterEach(mockFs.restore);
 });

--- a/test/android/findManifest.spec.js
+++ b/test/android/findManifest.spec.js
@@ -1,12 +1,12 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const findManifest = require('../../src/config/android/findManifest');
 const mockFs = require('mock-fs');
 const mocks = require('../fixtures/android');
 
 describe('android::findManifest', () => {
 
-  before(() => mockFs({
+  beforeEach(() => mockFs({
     empty: {},
     flat: {
       android: mocks.valid,
@@ -14,12 +14,12 @@ describe('android::findManifest', () => {
   }));
 
   it('should return a manifest path if file exists in the folder', () => {
-    expect(findManifest('flat')).to.be.a('string');
+    expect(typeof findManifest('flat')).toBe('string');
   });
 
   it('should return `null` if there is no manifest in the folder', () => {
-    expect(findManifest('empty')).to.be.null;
+    expect(findManifest('empty')).toBe(null);
   });
 
-  after(mockFs.restore);
+  afterEach(mockFs.restore);
 });

--- a/test/android/findPackageClassName.spec.js
+++ b/test/android/findPackageClassName.spec.js
@@ -1,12 +1,12 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const findPackageClassName = require('../../src/config/android/findPackageClassName');
 const mockFs = require('mock-fs');
 const mocks = require('../fixtures/android');
 
 describe('android::findPackageClassName', () => {
 
-  before(() => mockFs({
+  beforeEach(() => mockFs({
     empty: {},
     flat: {
       android: mocks.valid,
@@ -14,12 +14,12 @@ describe('android::findPackageClassName', () => {
   }));
 
   it('should return manifest content if file exists in the folder', () => {
-    expect(findPackageClassName('flat')).to.be.a('string');
+    expect(typeof findPackageClassName('flat')).toBe('string');
   });
 
   it('should return `null` if there\'s no matches', () => {
-    expect(findPackageClassName('empty')).to.be.null;
+    expect(findPackageClassName('empty')).toBe(null);
   });
 
-  after(mockFs.restore);
+  afterEach(mockFs.restore);
 });

--- a/test/android/getDependencyConfig.spec.js
+++ b/test/android/getDependencyConfig.spec.js
@@ -22,6 +22,7 @@ describe('android::getDependencyConfig', () => {
     const userConfig = {};
     const folder = 'nested';
 
+    expect(getDependencyConfig(folder, userConfig)).not.toBe(null);
     expect(typeof getDependencyConfig(folder, userConfig)).toBe('object');
   });
 

--- a/test/android/getDependencyConfig.spec.js
+++ b/test/android/getDependencyConfig.spec.js
@@ -14,6 +14,11 @@ describe('android::getDependencyConfig', () => {
         app: mocks.valid,
       },
     },
+    corrupted: {
+      android: {
+        app: mocks.corrupted,
+      },
+    },
     noPackage: {
       android: {},
     },
@@ -36,8 +41,8 @@ describe('android::getDependencyConfig', () => {
     expect(getDependencyConfig('noPackage', userConfig)).toBe(null);
   });
 
-  it('should return `null` if android project does not contain ReactPackage', () => {
-    expect(getDependencyConfig('noPackage', userConfig)).toBe(null);
+  it('should return `null` if it can\'t find a packageClassName', () => {
+    expect(getDependencyConfig('corrupted', userConfig)).toBe(null);
   });
 
   afterEach(mockFs.restore);

--- a/test/android/getDependencyConfig.spec.js
+++ b/test/android/getDependencyConfig.spec.js
@@ -1,12 +1,12 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const getDependencyConfig = require('../../src/config/android').dependencyConfig;
 const mockFs = require('mock-fs');
 const mocks = require('../fixtures/android');
 
 describe('android::getDependencyConfig', () => {
 
-  before(() => mockFs({
+  beforeEach(() => mockFs({
     empty: {},
     nested: {
       android: {
@@ -22,29 +22,29 @@ describe('android::getDependencyConfig', () => {
     const userConfig = {};
     const folder = 'nested';
 
-    expect(getDependencyConfig(folder, userConfig)).to.be.an('object');
+    expect(typeof getDependencyConfig(folder, userConfig)).toBe('object');
   });
 
   it('should return `null` if manifest file hasn\'t been found', () => {
     const userConfig = {};
     const folder = 'empty';
 
-    expect(getDependencyConfig(folder, userConfig)).to.be.null;
+    expect(getDependencyConfig(folder, userConfig)).toBe(null);
   });
 
   it('should return `null` if android project was not found', () => {
     const userConfig = {};
     const folder = 'empty';
 
-    expect(getDependencyConfig(folder, userConfig)).to.be.null;
+    expect(getDependencyConfig(folder, userConfig)).toBe(null);
   });
 
   it('should return `null` if android project does not contain ReactPackage', () => {
     const userConfig = {};
     const folder = 'noPackage';
 
-    expect(getDependencyConfig(folder, userConfig)).to.be.null;
+    expect(getDependencyConfig(folder, userConfig)).toBe(null);
   });
 
-  after(mockFs.restore);
+  afterEach(mockFs.restore);
 });

--- a/test/android/getDependencyConfig.spec.js
+++ b/test/android/getDependencyConfig.spec.js
@@ -3,6 +3,7 @@ jest.autoMockOff();
 const getDependencyConfig = require('../../src/config/android').dependencyConfig;
 const mockFs = require('mock-fs');
 const mocks = require('../fixtures/android');
+const userConfig = {};
 
 describe('android::getDependencyConfig', () => {
 
@@ -19,32 +20,24 @@ describe('android::getDependencyConfig', () => {
   }));
 
   it('should return an object with android project configuration', () => {
-    const userConfig = {};
-    const folder = 'nested';
-
-    expect(getDependencyConfig(folder, userConfig)).not.toBe(null);
-    expect(typeof getDependencyConfig(folder, userConfig)).toBe('object');
+    expect(getDependencyConfig('nested', userConfig)).not.toBe(null);
+    expect(typeof getDependencyConfig('nested', userConfig)).toBe('object');
   });
 
   it('should return `null` if manifest file hasn\'t been found', () => {
-    const userConfig = {};
-    const folder = 'empty';
-
-    expect(getDependencyConfig(folder, userConfig)).toBe(null);
+    expect(getDependencyConfig('empty', userConfig)).toBe(null);
   });
 
   it('should return `null` if android project was not found', () => {
-    const userConfig = {};
-    const folder = 'empty';
-
-    expect(getDependencyConfig(folder, userConfig)).toBe(null);
+    expect(getDependencyConfig('empty', userConfig)).toBe(null);
   });
 
   it('should return `null` if android project does not contain ReactPackage', () => {
-    const userConfig = {};
-    const folder = 'noPackage';
+    expect(getDependencyConfig('noPackage', userConfig)).toBe(null);
+  });
 
-    expect(getDependencyConfig(folder, userConfig)).toBe(null);
+  it('should return `null` if android project does not contain ReactPackage', () => {
+    expect(getDependencyConfig('noPackage', userConfig)).toBe(null);
   });
 
   afterEach(mockFs.restore);

--- a/test/android/getProjectConfig.spec.js
+++ b/test/android/getProjectConfig.spec.js
@@ -1,11 +1,11 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const getProjectConfig = require('../../src/config/android').projectConfig;
 const mockFs = require('mock-fs');
 const mocks = require('../fixtures/android');
 
 describe('android::getProjectConfig', () => {
-  before(() => mockFs({
+  beforeEach(() => mockFs({
     empty: {},
     nested: {
       android: {
@@ -24,7 +24,7 @@ describe('android::getProjectConfig', () => {
     const userConfig = {};
     const folder = 'noManifest';
 
-    expect(getProjectConfig(folder, userConfig)).to.be.null;
+    expect(getProjectConfig(folder, userConfig)).toBe(null);
   });
 
   describe('return an object with android project configuration for', () => {
@@ -32,14 +32,14 @@ describe('android::getProjectConfig', () => {
       const userConfig = {};
       const folder = 'nested';
 
-      expect(getProjectConfig(folder, userConfig)).to.be.an('object');
+      expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
     });
 
     it('flat structure', () => {
       const userConfig = {};
       const folder = 'flat';
 
-      expect(getProjectConfig(folder, userConfig)).to.be.an('object');
+      expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
     });
   });
 
@@ -47,8 +47,8 @@ describe('android::getProjectConfig', () => {
     const userConfig = {};
     const folder = 'empty';
 
-    expect(getProjectConfig(folder, userConfig)).to.be.null;
+    expect(getProjectConfig(folder, userConfig)).toBe(null);
   });
 
-  after(mockFs.restore);
+  afterEach(mockFs.restore);
 });

--- a/test/android/getProjectConfig.spec.js
+++ b/test/android/getProjectConfig.spec.js
@@ -32,6 +32,7 @@ describe('android::getProjectConfig', () => {
       const userConfig = {};
       const folder = 'nested';
 
+      expect(getProjectConfig(folder, userConfig)).not.toBe(null);
       expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
     });
 
@@ -39,6 +40,7 @@ describe('android::getProjectConfig', () => {
       const userConfig = {};
       const folder = 'flat';
 
+      expect(getProjectConfig(folder, userConfig)).not.toBe(null);
       expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
     });
   });

--- a/test/android/readManifest.spec.js
+++ b/test/android/readManifest.spec.js
@@ -18,6 +18,7 @@ describe('android::readManifest', () => {
 
   it('should return manifest content if file exists in the folder', () => {
     const manifestPath = findManifest('nested');
+    expect(readManifest(manifestPath)).not.toBe(null);
     expect(typeof readManifest(manifestPath)).toBe('object');
   });
 

--- a/test/android/readManifest.spec.js
+++ b/test/android/readManifest.spec.js
@@ -1,5 +1,5 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const findManifest = require('../../src/config/android/findManifest');
 const readManifest = require('../../src/config/android/readManifest');
 const mockFs = require('mock-fs');
@@ -7,7 +7,7 @@ const mocks = require('../fixtures/android');
 
 describe('android::readManifest', () => {
 
-  before(() => mockFs({
+  beforeEach(() => mockFs({
     empty: {},
     nested: {
       android: {
@@ -18,13 +18,13 @@ describe('android::readManifest', () => {
 
   it('should return manifest content if file exists in the folder', () => {
     const manifestPath = findManifest('nested');
-    expect(readManifest(manifestPath)).to.be.an('object');
+    expect(typeof readManifest(manifestPath)).toBe('object');
   });
 
   it('should throw an error if there is no manifest in the folder', () => {
     const fakeManifestPath = findManifest('empty');
-    expect(() => readManifest(fakeManifestPath)).to.throw(Error);
+    expect(() => readManifest(fakeManifestPath)).toThrow();
   });
 
-  after(mockFs.restore);
+  afterEach(mockFs.restore);
 });

--- a/test/findAssets.spec.js
+++ b/test/findAssets.spec.js
@@ -1,33 +1,31 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const findAssets = require('../src/config/findAssets');
 const mockFs = require('mock-fs');
 const dependencies = require('./fixtures/dependencies');
+const isArray = (arg) =>
+  Object.prototype.toString.call(arg) === '[object Array]';
 
 describe('findAssets', () => {
 
-  before(() => {
-    mockFs({ testDir: dependencies.withAssets });
-  });
+  beforeEach(() => mockFs({ testDir: dependencies.withAssets }));
 
   it('should return an array of all files in given folders', () => {
     const assets = findAssets('testDir', ['fonts', 'images']);
 
-    expect(assets).to.be.an('array');
-    expect(assets.length).to.equal(3);
+    expect(isArray(assets)).toBeTruthy();
+    expect(assets.length).toEqual(3);
   });
 
   it('should prepend assets paths with the folder path', () => {
     const assets = findAssets('testDir', ['fonts', 'images']);
 
-    assets.forEach(assetPath => expect(assetPath).to.contain('testDir'));
+    assets.forEach(assetPath => expect(assetPath).toContain('testDir'));
   });
 
   it('should return an empty array if given assets are null', () => {
-    expect(findAssets('testDir', null)).to.be.empty;
+    expect(findAssets('testDir', null).length).toEqual(0);
   });
 
-  after(() => {
-    mockFs.restore();
-  });
+  afterEach(mockFs.restore);
 });

--- a/test/findPlugins.js
+++ b/test/findPlugins.js
@@ -1,45 +1,46 @@
+jest.autoMockOff();
+
 const path = require('path');
-const expect = require('chai').expect;
 const findPlugins = require('../src/findPlugins');
-const mock = require('mock-require');
 
 const pjsonPath = path.join(process.cwd(), 'package.json');
+const isArray = (arg) =>
+  Object.prototype.toString.call(arg) === '[object Array]';
 
 describe('findPlugins', () => {
 
   it('should return an array of dependencies', () => {
-    mock(pjsonPath, {
+    jest.setMock(pjsonPath, {
       dependencies: { 'rnpm-plugin-test': '*' },
     });
-    expect(findPlugins([process.cwd()])).to.be.an('array');
+    expect(findPlugins([process.cwd()]).length).toBe(1);
+    expect(findPlugins([process.cwd()])[0]).toBe('rnpm-plugin-test');
   });
 
   it('should return an empty array if there\'re no plugins in this folder', () => {
-    mock(pjsonPath, {});
-    expect(findPlugins([process.cwd()])).to.be.empty;
+    jest.setMock(pjsonPath, {});
+    expect(findPlugins([process.cwd()]).length).toBe(0);
   });
 
   it('should return an empty array if there\'s no package.json in the supplied folder', () => {
-    expect(findPlugins(['fake-path'])).to.be.an('array');
-    expect(findPlugins(['fake-path'])).to.be.empty;
+    expect(isArray(findPlugins(['fake-path']))).toBeTruthy();
+    expect(findPlugins(['fake-path']).length).toBe(0);
   });
 
   it('should return plugins from both dependencies and dev dependencies', () => {
-    mock(pjsonPath, {
+    jest.setMock(pjsonPath, {
       dependencies: { 'rnpm-plugin-test': '*' },
       devDependencies: { 'rnpm-plugin-test-2': '*' },
     });
-    expect(findPlugins([process.cwd()]).length).to.equals(2);
+    expect(findPlugins([process.cwd()]).length).toEqual(2);
   });
 
   it('should return unique list of plugins', () => {
-    mock(pjsonPath, {
+    jest.setMock(pjsonPath, {
       dependencies: { 'rnpm-plugin-test': '*' },
       devDependencies: { 'rnpm-plugin-test': '*' },
     });
-    expect(findPlugins([process.cwd()]).length).to.equals(1);
+    expect(findPlugins([process.cwd()]).length).toEqual(1);
   });
-
-  afterEach(mock.stopAll);
 
 });

--- a/test/fixtures/android.js
+++ b/test/fixtures/android.js
@@ -20,6 +20,19 @@ exports.valid = {
   },
 };
 
+exports.corrupted = {
+  src: {
+    'AndroidManifest.xml': manifest,
+    main: {
+      com: {
+        some: {
+          example: {},
+        },
+      },
+    },
+  },
+};
+
 exports.noPackage = {
   src: {
     'AndroidManifest.xml': manifest,

--- a/test/getCommands.spec.js
+++ b/test/getCommands.spec.js
@@ -1,12 +1,12 @@
+jest.autoMockOff();
+
 const path = require('path');
-const expect = require('chai').expect;
-const getCommands = require('../src/getCommands');
 const mock = require('mock-require');
-const mockFs = require('mock-fs');
-const sinon = require('sinon');
 const rewire = require('rewire');
 
 const commands = require('./fixtures/commands');
+const isArray = (arg) =>
+  Object.prototype.toString.call(arg) === '[object Array]';
 
 /**
  * Paths to two possible `node_modules` locations `rnpm` can be installed
@@ -42,50 +42,45 @@ const NO_PLUGINS_JSON = {
   dependencies: {},
 };
 
+const getCommands = rewire('../src/getCommands');
+var revert;
+
 describe('getCommands', () => {
 
   afterEach(mock.stopAll);
 
   describe('in all installations', () => {
 
-    var getCommands;
-    var revert;
-
-    before(() => {
-      getCommands = rewire('../src/getCommands');
-      revert = getCommands.__set__({__dirname: path.join(LOCAL_NODE_MODULES, 'rnpm/src')});
-    });
-
-    /**
-     * In this suite we only test `rnpm` package.json, thus we make sure
-     * that project json on process.cwd() is properly mocked.
-     */
     beforeEach(() => {
+      revert = getCommands.__set__({
+        __dirname: path.join(LOCAL_NODE_MODULES, 'rnpm/src'),
+      });
       mock(APP_JSON, NO_PLUGINS_JSON);
     });
 
-    after(() => revert());
+    afterEach(() => revert());
 
-    it('list of the commands should be a non-empty array', () => {
+    it.only('list of the commands should be a non-empty array', () => {
+      mock(APP_JSON, NO_PLUGINS_JSON);
       mock(LOCAL_RNPM_PJSON, SAMPLE_RNPM_JSON);
       mock(SAMPLE_RNPM_PLUGIN, commands.single);
 
-      expect(getCommands()).to.be.not.empty;
-      expect(getCommands()).to.be.an('array');
+      expect(getCommands().length).not.toBe(0);
+      expect(isArray(getCommands())).toBeTruthy();
     });
 
     it('should export one command', () => {
       mock(LOCAL_RNPM_PJSON, SAMPLE_RNPM_JSON);
       mock(SAMPLE_RNPM_PLUGIN, commands.single);
 
-      expect(getCommands().length).to.be.equal(1);
+      expect(getCommands().length).toEqual(1);
     });
 
     it('should export multiple commands', () => {
       mock(LOCAL_RNPM_PJSON, SAMPLE_RNPM_JSON);
       mock(SAMPLE_RNPM_PLUGIN, commands.multiple);
 
-      expect(getCommands().length).to.be.equal(2);
+      expect(getCommands().length).toEqual(2);
     });
 
     it('should export unique list of commands by name', () => {
@@ -99,20 +94,12 @@ describe('getCommands', () => {
       mock(SAMPLE_RNPM_PLUGIN, commands.single);
       mock(`${SAMPLE_RNPM_PLUGIN}-2`, commands.single);
 
-      expect(getCommands().length).to.be.equal(1);
+      expect(getCommands().length).toEqual(1);
     });
 
   });
 
   describe('project plugins', () => {
-
-    var getCommands;
-    var revert;
-
-    before(() => {
-      getCommands = rewire('../src/getCommands');
-    });
-
     /**
      * In this test suite we only test project plugins thus we make sure
      * `rnpm` package.json is properly mocked
@@ -125,7 +112,9 @@ describe('getCommands', () => {
     afterEach(() => revert());
 
     it('shoud load when installed locally', () => {
-      revert = getCommands.__set__({__dirname: path.join(LOCAL_NODE_MODULES, 'rnpm/src')});
+      revert = getCommands.__set__({
+        __dirname: path.join(LOCAL_NODE_MODULES, 'rnpm/src'),
+      });
 
       mock(APP_JSON, SAMPLE_RNPM_JSON);
       mock(
@@ -133,11 +122,13 @@ describe('getCommands', () => {
         commands.single
       );
 
-      expect(getCommands()[0]).to.be.equal(commands.single);
+      expect(getCommands()[0]).toEqual(commands.single);
     });
 
     it('should load when installed globally', () => {
-      revert = getCommands.__set__({__dirname: path.join(GLOBAL_NODE_MODULES, 'rnpm/src')});
+      revert = getCommands.__set__({
+        __dirname: path.join(GLOBAL_NODE_MODULES, 'rnpm/src'),
+      });
 
       mock(APP_JSON, SAMPLE_RNPM_JSON);
       mock(
@@ -145,22 +136,19 @@ describe('getCommands', () => {
         commands.single
       );
 
-      expect(getCommands()[0]).to.be.equal(commands.single);
+      expect(getCommands()[0]).toEqual(commands.single);
     });
 
   });
 
   describe('rnpm and project plugins', () => {
 
-    var getCommands;
-    var revert;
-
-    before(() => {
+    beforeEach(() => {
       getCommands = rewire('../src/getCommands');
       revert = getCommands.__set__({__dirname: path.join(LOCAL_NODE_MODULES, 'rnpm/src')});
     });
 
-    after(() => revert());
+    afterEach(() => revert());
 
     it('should load concatenated list of plugins', () => {
       mock(APP_JSON, SAMPLE_RNPM_JSON);
@@ -176,9 +164,7 @@ describe('getCommands', () => {
       );
       mock(`${SAMPLE_RNPM_PLUGIN}-2`, commands.single);
 
-      expect(getCommands().length).to.be.equal(3);
+      expect(getCommands().length).toEqual(3);
     });
-
   });
-
 });

--- a/test/getCommands.spec.js
+++ b/test/getCommands.spec.js
@@ -60,7 +60,7 @@ describe('getCommands', () => {
 
     afterEach(() => revert());
 
-    it.only('list of the commands should be a non-empty array', () => {
+    it('list of the commands should be a non-empty array', () => {
       mock(APP_JSON, NO_PLUGINS_JSON);
       mock(LOCAL_RNPM_PJSON, SAMPLE_RNPM_JSON);
       mock(SAMPLE_RNPM_PLUGIN, commands.single);
@@ -144,8 +144,9 @@ describe('getCommands', () => {
   describe('rnpm and project plugins', () => {
 
     beforeEach(() => {
-      getCommands = rewire('../src/getCommands');
-      revert = getCommands.__set__({__dirname: path.join(LOCAL_NODE_MODULES, 'rnpm/src')});
+      revert = getCommands.__set__({
+        __dirname: path.join(LOCAL_NODE_MODULES, 'rnpm/src'),
+      });
     });
 
     afterEach(() => revert());

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -3,6 +3,7 @@ jest.autoMockOff();
 const findProject = require('../../src/config/ios/findProject');
 const mockFs = require('mock-fs');
 const projects = require('../fixtures/projects');
+const userConfig = {};
 
 describe('ios::findProject', () => {
 
@@ -11,16 +12,17 @@ describe('ios::findProject', () => {
   });
 
   it('should return path to xcodeproj if found', () => {
-    const userConfig = {};
 
     mockFs(projects.flat);
 
     expect(findProject('')).toContain('.xcodeproj');
   });
 
-  it('should ignore xcodeproj from example folders', () => {
-    const userConfig = {};
+  it('should return null if there\'re no projects', () => {
+    expect(findProject('')).toBe(null);
+  });
 
+  it('should ignore xcodeproj from example folders', () => {
     mockFs({
       examples: projects.flat,
       Examples: projects.flat,
@@ -33,8 +35,6 @@ describe('ios::findProject', () => {
   });
 
   it('should ignore xcodeproj from test folders at any level', () => {
-    const userConfig = {};
-
     mockFs({
       test: projects.flat,
       IntegrationTests: projects.flat,

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -1,12 +1,12 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const findProject = require('../../src/config/ios/findProject');
 const mockFs = require('mock-fs');
 const projects = require('../fixtures/projects');
 
 describe('ios::findProject', () => {
 
-  before(() => {
+  beforeEach(() => {
     mockFs({ testDir: projects });
   });
 
@@ -15,7 +15,7 @@ describe('ios::findProject', () => {
 
     mockFs(projects.flat);
 
-    expect(findProject('')).to.contain('.xcodeproj');
+    expect(findProject('')).toContain('.xcodeproj');
   });
 
   it('should ignore xcodeproj from example folders', () => {
@@ -29,7 +29,7 @@ describe('ios::findProject', () => {
       Zpp: projects.flat,
     });
 
-    expect(findProject('').toLowerCase()).to.not.contain('example');
+    expect(findProject('').toLowerCase()).not.toContain('example');
   });
 
   it('should ignore xcodeproj from test folders at any level', () => {
@@ -45,11 +45,8 @@ describe('ios::findProject', () => {
       },
     });
 
-    expect(findProject('').toLowerCase()).to.not.contain('test');
+    expect(findProject('').toLowerCase()).not.toContain('test');
   });
 
-  afterEach(() => {
-    mockFs.restore();
-  });
-
+  afterEach(mockFs.restore);
 });

--- a/test/ios/getProjectConfig.spec.js
+++ b/test/ios/getProjectConfig.spec.js
@@ -1,31 +1,25 @@
-const path = require('path');
-const expect = require('chai').expect;
+jest.autoMockOff();
+
 const getProjectConfig = require('../../src/config/ios').projectConfig;
 const mockFs = require('mock-fs');
 const projects = require('../fixtures/projects');
 
 describe('ios::getProjectConfig', () => {
+  const userConfig = {};
 
-  before(() => {
-    mockFs({ testDir: projects });
-  });
+  beforeEach(() => mockFs({ testDir: projects }));
 
   it('should return an object with ios project configuration', () => {
-    const userConfig = {};
-    const folder = path.join('testDir', 'nested');
+    const folder = 'testDir/nested';
 
-    expect(getProjectConfig(folder, userConfig)).to.be.an('object');
+    expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
   });
 
   it('should return `null` if ios project was not found', () => {
-    const userConfig = {};
-    const folder = path.join('testDir', 'empty');
+    const folder = 'testDir/empty';
 
-    expect(getProjectConfig(folder, userConfig)).to.be.null;
+    expect(getProjectConfig(folder, userConfig)).toBe(null);
   });
 
-  after(() => {
-    mockFs.restore();
-  });
-
+  afterEach(mockFs.restore);
 });

--- a/test/ios/getProjectConfig.spec.js
+++ b/test/ios/getProjectConfig.spec.js
@@ -7,9 +7,12 @@ const projects = require('../fixtures/projects');
 describe('ios::getProjectConfig', () => {
   const userConfig = {};
 
+  beforeEach(() => mockFs({ testDir: projects }));
+
   it('should return an object with ios project configuration', () => {
     const folder = 'testDir/nested';
 
+    expect(getProjectConfig(folder, userConfig)).not.toBe(null);
     expect(typeof getProjectConfig(folder, userConfig)).toBe('object');
   });
 
@@ -18,4 +21,6 @@ describe('ios::getProjectConfig', () => {
 
     expect(getProjectConfig(folder, userConfig)).toBe(null);
   });
+
+  afterEach(mockFs.restore);
 });

--- a/test/ios/getProjectConfig.spec.js
+++ b/test/ios/getProjectConfig.spec.js
@@ -7,8 +7,6 @@ const projects = require('../fixtures/projects');
 describe('ios::getProjectConfig', () => {
   const userConfig = {};
 
-  beforeEach(() => mockFs({ testDir: projects }));
-
   it('should return an object with ios project configuration', () => {
     const folder = 'testDir/nested';
 
@@ -20,6 +18,4 @@ describe('ios::getProjectConfig', () => {
 
     expect(getProjectConfig(folder, userConfig)).toBe(null);
   });
-
-  afterEach(mockFs.restore);
 });

--- a/test/makeCommand.spec.js
+++ b/test/makeCommand.spec.js
@@ -24,9 +24,7 @@ describe('makeCommand', () => {
     const spy = jest.genMockFunction();
     command(spy);
 
-    setTimeout(() => {
-      expect(spy.mock.calls.length).toBe(1);
-    }, 1);
+    expect(spy.mock.calls.length).toBe(1);
   });
 
   it('should throw an error if spawn ended up with error', () => {

--- a/test/makeCommand.spec.js
+++ b/test/makeCommand.spec.js
@@ -1,4 +1,11 @@
-jest.autoMockOff();
+var spawnError = false;
+
+jest.setMock('child_process', {
+  spawn: () => ({
+    on: (ev, cb) => cb(spawnError),
+  }),
+});
+jest.dontMock('../src/makeCommand');
 
 const makeCommand = require('../src/makeCommand');
 
@@ -13,14 +20,18 @@ describe('makeCommand', () => {
     expect(command).toThrow();
   });
 
-  it('should invoke a callback after command execution', (done) => {
+  it('should invoke a callback after command execution', () => {
     const spy = jest.genMockFunction();
-
     command(spy);
 
     setTimeout(() => {
-      expect(spy.calls.length).toBe(1);
-      done();
+      expect(spy.mock.calls.length).toBe(1);
     }, 1);
+  });
+
+  it('should throw an error if spawn ended up with error', () => {
+    spawnError = true;
+    const cb = jest.genMockFunction();
+    expect(() => command(cb)).toThrow();
   });
 });

--- a/test/makeCommand.spec.js
+++ b/test/makeCommand.spec.js
@@ -1,27 +1,26 @@
-const path = require('path');
-const expect = require('chai').expect;
-const sinon = require('sinon');
+jest.autoMockOff();
+
 const makeCommand = require('../src/makeCommand');
 
-const command = makeCommand('echo');
-
 describe('makeCommand', () => {
+  const command = makeCommand('echo');
+
   it('should generate a function around shell command', () => {
-    expect(typeof command).to.be.equal('function');
+    expect(typeof command).toBe('function');
   });
 
   it('should throw an error if there\'s no callback provided', () => {
-    expect(command).to.throw(/missed a callback/);
+    expect(command).toThrow();
   });
 
   it('should invoke a callback after command execution', (done) => {
-    const spy = sinon.spy();
+    const spy = jest.genMockFunction();
 
     command(spy);
 
     setTimeout(() => {
-      expect(spy.calledOnce).to.be.true;
+      expect(spy.calls.length).toBe(1);
       done();
-    }, 100);
+    }, 1);
   });
 });


### PR DESCRIPTION
For a painless merging `rnpm` in `react-native`'s core, we need to migrate our test stack to Jest.

**What's done:**
- [x] Replaced mocha + chai + sinon by Jest
- [x] Code coverage is now a Jest responsibility (it includes Istanbul by default)
- [x] Code coverage has been improved
- [x] Fixed some buggy edge cases