### PR TITLE
Fix CircleCi

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,17 @@ machine:
   node:
     version: 4.2.1
 
-test:
+dependencies:
   pre:
     - npm install codeclimate-test-reporter@0.1
-  post:
-    - codeclimate-test-reporter < coverage/lcov.info
-
+    
+deployment:
+  coverage: 
+    branch: master
+    owner: rnpm
+    commands:
+      - codeclimate-test-reporter < coverage/lcov.info
+ 
 notify:
   webhooks:
     - url: https://webhooks.gitter.im/e/bf9cb7240681c7263e6b


### PR DESCRIPTION
Latest commit makes it run code coverage after every test suite and send code coverage even from other branches / forks. That is of course bad behaviour causing all PRs from forked repos to fail https://circleci.com/gh/rnpm/rnpm/175

We should explicitly send code coverage only when branch is master and we are in rnpm own repository.