### PR TITLE
Optimize tests for Jasmine runner v2

### DIFF
--- a/test/android/findAndroidAppFolder.spec.js
+++ b/test/android/findAndroidAppFolder.spec.js
@@ -5,7 +5,7 @@ const mockFs = require('mock-fs');
 const mocks = require('../fixtures/android');
 
 describe('android::findAndroidAppFolder', () => {
-  beforeEach(() => mockFs({
+  beforeAll(() => mockFs({
     empty: {},
     nested: {
       android: {
@@ -26,5 +26,5 @@ describe('android::findAndroidAppFolder', () => {
     expect(findAndroidAppFolder('empty')).toBe(null);
   });
 
-  afterEach(mockFs.restore);
+  afterAll(mockFs.restore);
 });

--- a/test/android/findManifest.spec.js
+++ b/test/android/findManifest.spec.js
@@ -6,7 +6,7 @@ const mocks = require('../fixtures/android');
 
 describe('android::findManifest', () => {
 
-  beforeEach(() => mockFs({
+  beforeAll(() => mockFs({
     empty: {},
     flat: {
       android: mocks.valid,
@@ -21,5 +21,5 @@ describe('android::findManifest', () => {
     expect(findManifest('empty')).toBe(null);
   });
 
-  afterEach(mockFs.restore);
+  afterAll(mockFs.restore);
 });

--- a/test/android/findPackageClassName.spec.js
+++ b/test/android/findPackageClassName.spec.js
@@ -6,7 +6,7 @@ const mocks = require('../fixtures/android');
 
 describe('android::findPackageClassName', () => {
 
-  beforeEach(() => mockFs({
+  beforeAll(() => mockFs({
     empty: {},
     flat: {
       android: mocks.valid,
@@ -21,5 +21,5 @@ describe('android::findPackageClassName', () => {
     expect(findPackageClassName('empty')).toBe(null);
   });
 
-  afterEach(mockFs.restore);
+  afterAll(mockFs.restore);
 });

--- a/test/android/getDependencyConfig.spec.js
+++ b/test/android/getDependencyConfig.spec.js
@@ -7,7 +7,7 @@ const userConfig = {};
 
 describe('android::getDependencyConfig', () => {
 
-  beforeEach(() => mockFs({
+  beforeAll(() => mockFs({
     empty: {},
     nested: {
       android: {
@@ -45,5 +45,5 @@ describe('android::getDependencyConfig', () => {
     expect(getDependencyConfig('corrupted', userConfig)).toBe(null);
   });
 
-  afterEach(mockFs.restore);
+  afterAll(mockFs.restore);
 });

--- a/test/android/getProjectConfig.spec.js
+++ b/test/android/getProjectConfig.spec.js
@@ -5,7 +5,7 @@ const mockFs = require('mock-fs');
 const mocks = require('../fixtures/android');
 
 describe('android::getProjectConfig', () => {
-  beforeEach(() => mockFs({
+  beforeAll(() => mockFs({
     empty: {},
     nested: {
       android: {
@@ -52,5 +52,5 @@ describe('android::getProjectConfig', () => {
     expect(getProjectConfig(folder, userConfig)).toBe(null);
   });
 
-  afterEach(mockFs.restore);
+  afterAll(mockFs.restore);
 });

--- a/test/android/readManifest.spec.js
+++ b/test/android/readManifest.spec.js
@@ -7,7 +7,7 @@ const mocks = require('../fixtures/android');
 
 describe('android::readManifest', () => {
 
-  beforeEach(() => mockFs({
+  beforeAll(() => mockFs({
     empty: {},
     nested: {
       android: {
@@ -27,5 +27,5 @@ describe('android::readManifest', () => {
     expect(() => readManifest(fakeManifestPath)).toThrow();
   });
 
-  afterEach(mockFs.restore);
+  afterAll(mockFs.restore);
 });


### PR DESCRIPTION
`before/afterEach` replaced by `before/afterAll` where it's possible.