### PR TITLE
Do not ignore ios folder

### DIFF
--- a/src/config/ios/findProject.js
+++ b/src/config/ios/findProject.js
@@ -32,12 +32,11 @@ module.exports = function findProject(folder) {
   const projects = glob
     .sync(GLOB_PATTERN, {
       cwd: folder,
-      root: folder,
       ignore: GLOB_EXCLUDE_PATTERN,
     })
-    .filter(path => {
-      const p = path.toLowerCase();
-      return p.indexOf(IOS_BASE) === 0 || !p.match(TEST_PROJECTS);
+    .filter(xcPath => {
+      const path = xcPath.toLowerCase();
+      return path.indexOf(IOS_BASE) === 0 || !path.match(TEST_PROJECTS);
     });
 
   if (projects.length === 0) {

--- a/src/config/ios/findProject.js
+++ b/src/config/ios/findProject.js
@@ -6,21 +6,39 @@ const glob = require('glob');
 const GLOB_PATTERN = '**/*.xcodeproj';
 
 /**
+ * Regexp matching all test projects
+ */
+const TEST_PROJECTS = /(test|example)/;
+
+/**
+ * Base iOS folder
+ */
+const IOS_BASE = 'ios/';
+
+/**
  * These folders will be excluded from search to speed it up
  */
-const GLOB_EXCLUDE_PATTERN = ['node_modules/**', '**/*@(E|e)xample*/**', '**/*@(T|t)est*/**', 'Pods/**'];
+const GLOB_EXCLUDE_PATTERN = ['@(Pods|node_modules)/**'];
 
 /**
  * Finds iOS project by looking for all .xcodeproj files
  * in given folder.
  *
  * Returns first match if files are found or null
+ *
+ * Note: `./ios/*.xcodeproj` are returned regardless of the name
  */
 module.exports = function findProject(folder) {
-  const projects = glob.sync(GLOB_PATTERN, {
-    cwd: folder,
-    ignore: GLOB_EXCLUDE_PATTERN,
-  });
+  const projects = glob
+    .sync(GLOB_PATTERN, {
+      cwd: folder,
+      root: folder,
+      ignore: GLOB_EXCLUDE_PATTERN,
+    })
+    .filter(path => {
+      const p = path.toLowerCase();
+      return p.indexOf(IOS_BASE) === 0 || !p.match(TEST_PROJECTS);
+    });
 
   if (projects.length === 0) {
     return null;

--- a/src/config/ios/findProject.js
+++ b/src/config/ios/findProject.js
@@ -1,4 +1,5 @@
 const glob = require('glob');
+const path = require('path');
 
 /**
  * Glob pattern to look for xcodeproj
@@ -13,7 +14,7 @@ const TEST_PROJECTS = /(test|example)/;
 /**
  * Base iOS folder
  */
-const IOS_BASE = 'ios/';
+const IOS_BASE = 'ios';
 
 /**
  * These folders will be excluded from search to speed it up
@@ -34,9 +35,9 @@ module.exports = function findProject(folder) {
       cwd: folder,
       ignore: GLOB_EXCLUDE_PATTERN,
     })
-    .filter(xcPath => {
-      const path = xcPath.toLowerCase();
-      return path.indexOf(IOS_BASE) === 0 || !path.match(TEST_PROJECTS);
+    .filter(project => {
+      const xcPath = project.toLowerCase();
+      return path.dirname(xcPath) === IOS_BASE || !xcPath.match(TEST_PROJECTS);
     });
 
   if (projects.length === 0) {

--- a/test/fixtures/ios.js
+++ b/test/fixtures/ios.js
@@ -6,3 +6,9 @@ exports.valid = {
     'project.pbxproj': fs.readFileSync(path.join(__dirname, './files/project.pbxproj')),
   },
 };
+
+exports.validTestName = {
+  'MyTestProject.xcodeproj': {
+    'project.pbxproj': fs.readFileSync(path.join(__dirname, './files/project.pbxproj')),
+  },
+};

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -3,6 +3,7 @@ jest.autoMockOff();
 const findProject = require('../../src/config/ios/findProject');
 const mockFs = require('mock-fs');
 const projects = require('../fixtures/projects');
+const ios = require('../fixtures/ios');
 const userConfig = {};
 
 describe('ios::findProject', () => {
@@ -12,13 +13,26 @@ describe('ios::findProject', () => {
   });
 
   it('should return path to xcodeproj if found', () => {
-
     mockFs(projects.flat);
-
-    expect(findProject('')).toContain('.xcodeproj');
+    expect(findProject('')).not.toBe(null);
   });
 
   it('should return null if there\'re no projects', () => {
+    expect(findProject('')).toBe(null);
+  });
+
+  it('should return ios project regardless of its name', () => {
+    mockFs({ ios: ios.validTestName });
+    expect(findProject('')).not.toBe(null);
+  });
+
+  it('should ignore node_modules', () => {
+    mockFs({ node_modules: projects.flat });
+    expect(findProject('')).toBe(null);
+  });
+
+  it('should ignore Pods', () => {
+    mockFs({ Pods: projects.flat });
     expect(findProject('')).toBe(null);
   });
 

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -7,17 +7,13 @@ const ios = require('../fixtures/ios');
 const userConfig = {};
 
 describe('ios::findProject', () => {
-
-  beforeEach(() => {
-    mockFs({ testDir: projects });
-  });
-
   it('should return path to xcodeproj if found', () => {
     mockFs(projects.flat);
     expect(findProject('')).not.toBe(null);
   });
 
   it('should return null if there\'re no projects', () => {
+    mockFs({ testDir: projects });
     expect(findProject('')).toBe(null);
   });
 


### PR DESCRIPTION
Fixes #120

Prefers `ios` project from `ios/xyz.xcodeproj` regardless of its name. This is to handle cases where people create apps with CLI named `MyTestApp` and we want it to work in such case.