### PR TITLE
exclude Pods in child folders

### DIFF
--- a/src/config/ios/findProject.js
+++ b/src/config/ios/findProject.js
@@ -19,7 +19,7 @@ const IOS_BASE = 'ios';
 /**
  * These folders will be excluded from search to speed it up
  */
-const GLOB_EXCLUDE_PATTERN = ['@(Pods|node_modules)/**'];
+const GLOB_EXCLUDE_PATTERN = ['@(Pods|node_modules)/**', '**/@(Pods|node_modules)/**'];
 
 /**
  * Finds iOS project by looking for all .xcodeproj files

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -27,20 +27,20 @@ describe('ios::findProject', () => {
     expect(findProject('')).toBe(null);
   });
 
-  it('should ignore node_modules in child folders'. () => {
+  it('should ignore node_modules in child folders', () => {
     mockFs({ ios: { node_modules: projects.flat }});
-    expect((findProject('').toBe(null)));
-  })
+    expect(findProject('')).toBe(null);
+  });
 
   it('should ignore Pods', () => {
     mockFs({ Pods: projects.flat });
     expect(findProject('')).toBe(null);
   });
 
-  it('should ignore Pods in child folders'. () => {
+  it('should ignore node_modules in child folders', () => {
     mockFs({ ios: { Pods: projects.flat }});
-    expect((findProject('').toBe(null)));
-  })
+    expect(findProject('')).toBe(null);
+  });
 
   it('should ignore xcodeproj from example folders', () => {
     mockFs({

--- a/test/ios/findProject.spec.js
+++ b/test/ios/findProject.spec.js
@@ -27,10 +27,20 @@ describe('ios::findProject', () => {
     expect(findProject('')).toBe(null);
   });
 
+  it('should ignore node_modules in child folders'. () => {
+    mockFs({ ios: { node_modules: projects.flat }});
+    expect((findProject('').toBe(null)));
+  })
+
   it('should ignore Pods', () => {
     mockFs({ Pods: projects.flat });
     expect(findProject('')).toBe(null);
   });
+
+  it('should ignore Pods in child folders'. () => {
+    mockFs({ ios: { Pods: projects.flat }});
+    expect((findProject('').toBe(null)));
+  })
 
   it('should ignore xcodeproj from example folders', () => {
     mockFs({


### PR DESCRIPTION
I have my Pod folder in ios folder like this
|- react-native
   |- ios
      |- Pods
         |- pod.xcodeproj

And this project is picked up by rnpm so adding dependencies to iOS fails. Add additional ignore path to prevent this