### PR TITLE
Use a stub instead of package.json if it's not found in the linking folder

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -30,7 +30,14 @@ exports.getProjectConfig = function getProjectConfig() {
  */
 exports.getDependencyConfig = function getDependencyConfig(packageName) {
   const folder = path.join(process.cwd(), 'node_modules', packageName);
-  const rnpm = getRNPMConfig(folder);
+  var rnpm;
+
+  // Will throw when package.json is not present in a nested folder
+  try {
+    rnpm = getRNPMConfig(folder);
+  } catch (err) {
+    rnpm = {};
+  }
 
   return Object.assign({}, rnpm, {
     ios: ios.dependencyConfig(folder, rnpm.ios || {}),


### PR DESCRIPTION
Fixes #144 

I've had a nice thought this morning, instead of supporting an array of projects, we can be more explicit and just:
```
rnpm link react-native-fbsdk/iOS/core
```

Tested on iOS.

```
rnpm unlink react-native-fbsdk
rnpm-link info Unlinking react-native-fbsdk/iOS/core ios dependency
rnpm-link info iOS module react-native-fbsdk/iOS/core has been successfully unlinked
```

Android should probably work as well.

This PR just makes the `package.json` for a dependency optional. We can probably traverse up to find the nearest package.json scoped to that dependency, but there are cases like '@scope/name` that I don't want to address just yet. Since no-one really requested that feature and it's only facebook shipping that way at this point, I think it's fine.