### PR TITLE
Support flags in rnpm

### DIFF
--- a/bin/cli
+++ b/bin/cli
@@ -12,15 +12,25 @@ updateNotifier({ pkg }).notify();
 
 cli.version(pkg.version);
 
-const addCommand = (command) =>
-  cli
+const defaultOptParser = (val) => val;
+
+const addCommand = (command) => {
+  const cmd = cli
     .command(command.name)
     .usage(command.usage)
     .description(command.description)
     .action(function runAction() {
-      command.func(config, arguments);
+      command.func(config, arguments, this.opts());
     });
 
+  (command.options || [])
+    .forEach(opt => cmd.option(
+      opt.flags,
+      opt.description,
+      opt.parse || defaultOptParser,
+      opt.default
+    ));
+};
 
 flatten(commands).forEach(addCommand);
 


### PR DESCRIPTION
A plugin can now define:
```
options: [{
    flags: '-L, --list [path]',
    description: 'List flag',
    parse: (val) => val.split(',').map(Number),
    default: [1,2,3],
  }],
```
and will receive an object with e.g. `{ list: [1,2,3] }` as a 3rd argument to the exported function.

Note: All values are optional/required as per `commander.js` documentation. In this case, default value and parse can be omitted. Syntax for defining flags is explained in the commander repo.

Test screenshot:
<img width="411" alt="screen shot 2016-05-27 at 18 38 47" src="https://cloud.githubusercontent.com/assets/2464966/15614637/49eb585e-243a-11e6-96f9-2649498cc449.png">
