### PR TITLE
Support specifying iOS shared libraries

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "devDependencies": {
     "babel-eslint": "^4.1.5",
     "eslint": "^1.9.0",
-    "mock-fs": "^3.5.0",
+    "mock-fs": "^3.9.0",
     "mock-require": "^1.2.1",
     "rewire": "^2.5.1",
     "jest-cli": "^0.9.0-fb2"

--- a/src/config/ios/index.js
+++ b/src/config/ios/index.js
@@ -2,6 +2,19 @@ const path = require('path');
 const findProject = require('./findProject');
 
 /**
+ * For libraries specified without an extension, add '.tbd' for those that
+ * start with 'lib' and '.framework' to the rest.
+ */
+const mapSharedLibaries = (libraries) => {
+  return libraries.map(name => {
+    if (path.extname(name)) {
+      return name;
+    }
+    return name + (name.indexOf('lib') === 0 ? '.tbd' : '.framework');
+  });
+};
+
+/**
  * Returns project config by analyzing given folder and applying some user defaults
  * when constructing final object
  */
@@ -24,6 +37,7 @@ exports.projectConfig = function projectConfigIOS(folder, userConfig) {
     projectPath: projectPath,
     projectName: path.basename(projectPath),
     libraryFolder: userConfig.libraryFolder || 'Libraries',
+    sharedLibraries: mapSharedLibaries(userConfig.sharedLibraries || []),
     plist: userConfig.plist || [],
   };
 };

--- a/test/ios/getProjectConfig.spec.js
+++ b/test/ios/getProjectConfig.spec.js
@@ -22,5 +22,15 @@ describe('ios::getProjectConfig', () => {
     expect(getProjectConfig(folder, userConfig)).toBe(null);
   });
 
+  it('should return normalized shared library names', () => {
+    const projectConfig = getProjectConfig('testDir/nested', {
+      sharedLibraries: ['libc++', 'libz.tbd', 'HealthKit', 'HomeKit.framework'],
+    });
+
+    expect(projectConfig.sharedLibraries).toEqual(
+      ['libc++.tbd', 'libz.tbd', 'HealthKit.framework', 'HomeKit.framework']
+    );
+  });
+
   afterEach(mockFs.restore);
 });


### PR DESCRIPTION
This relates to #122, but the bulk of the work must be done in npm-plugin-link. A PR in that repo will follow shortly.