### PR TITLE
Support react-native plugins

### DIFF
--- a/src/findPlugins.js
+++ b/src/findPlugins.js
@@ -9,7 +9,7 @@ const flatten = require('lodash').flatten;
  * @param  {String} dependency Name of the dependency
  * @return {Boolean}           If dependency is a rnpm plugin
  */
-const isRNPMPlugin = (dependency) => !!~dependency.indexOf('rnpm-plugin-')
+const isRNPMPlugin = (dependency) => !!~dependency.indexOf('rnpm-plugin-');
 const isReactNativePlugin = (dependency) => !!~dependency.indexOf('react-native-');
 
 const readPackage = (folder) => {
@@ -21,11 +21,11 @@ const readPackage = (folder) => {
 };
 
 const findPluginsInReactNativePackage = (pjson) => {
-  if (!pjson.rnpm || !pjson.rnpm.commands) {
+  if (!pjson.rnpm || !pjson.rnpm.plugin) {
     return [];
   }
 
-  return path.join(pjson.name, pjson.rnpm.commands);
+  return path.join(pjson.name, pjson.rnpm.plugin);
 };
 
 const findPluginInFolder = (folder) => {

--- a/src/findPlugins.js
+++ b/src/findPlugins.js
@@ -9,13 +9,29 @@ const flatten = require('lodash').flatten;
  * @param  {String} dependency Name of the dependency
  * @return {Boolean}           If dependency is a rnpm plugin
  */
-const isPlugin = (dependency) => !!~dependency.indexOf('rnpm-plugin-');
+const isRNPMPlugin = (dependency) => !!~dependency.indexOf('rnpm-plugin-')
+const isReactNativePlugin = (dependency) => !!~dependency.indexOf('react-native-');
+
+const readPackage = (folder) => {
+  try {
+    return require(path.join(folder, 'package.json'));
+  } catch (e) {
+    return null;
+  }
+};
+
+const findPluginsInReactNativePackage = (pjson) => {
+  if (!pjson.rnpm || !pjson.rnpm.commands) {
+    return [];
+  }
+
+  return path.join(pjson.name, pjson.rnpm.commands);
+};
 
 const findPluginInFolder = (folder) => {
-  var pjson;
-  try {
-    pjson = require(path.join(folder, 'package.json'));
-  } catch (e) {
+  const pjson = readPackage(folder);
+
+  if (!pjson) {
     return [];
   }
 
@@ -24,7 +40,22 @@ const findPluginInFolder = (folder) => {
     Object.keys(pjson.devDependencies || {})
   );
 
-  return deps.filter(isPlugin);
+  return deps.reduce(
+    (acc, pkg) => {
+      if (isRNPMPlugin(pkg)) {
+        return acc.concat(pkg);
+      }
+      if (isReactNativePlugin(pkg)) {
+        const pjson = readPackage(path.join(folder, 'node_modules', pkg));
+        if (!pjson) {
+          return acc;
+        }
+        return acc.concat(findPluginsInReactNativePackage(pjson));
+      }
+      return acc;
+    },
+    []
+  );
 };
 
 /**


### PR DESCRIPTION
`rnpm` looks for `rnpm-plugin-<name>` and just requires it to load new commands. Sometimes though, a `react-native-<name>` package also wants to expose some companion commands, like react-native-windows w/o need to publish another module.

This pull request implements this feature in a backwards compatible manner.

Package should add:

``` json
"rnpm": {
  "plugin": "./cli/index.js",
}
```

to point to an entry-file of a plugin (if supported). `cli/index.js` in regards to content should be the same as in any other rnpm plugin.

CC: @rozele
